### PR TITLE
Feature/ast and defs

### DIFF
--- a/example.lambda
+++ b/example.lambda
@@ -1,1 +1,0 @@
-((λ x (λ y x)) "Hello, world!")

--- a/examples/church.lambda
+++ b/examples/church.lambda
@@ -1,0 +1,6 @@
+zero = (λ f (λ x x))
+one = (λ f (λ x (f x)))
+two = (λ f (λ x (f (f x))))
+three = (λ f (λ x (f ((two f) x))))
+const = (λ x (λ y x))
+main = (three const) "whoa"

--- a/examples/def.lambda
+++ b/examples/def.lambda
@@ -1,0 +1,3 @@
+const = (λ x (λ y x))
+id = (λ x x)
+main = (((const id) const) (λ y (λ x (λ z y))))

--- a/examples/helloworld.lambda
+++ b/examples/helloworld.lambda
@@ -1,0 +1,1 @@
+((λ x (λ y x)) "Hello, world!")

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -11,8 +11,8 @@ import Parser (Parser, char, identifier, expr)
 type Definition = (Identifier, Expr)
 
 data AST = AST
-  { defs :: [Definition]
-  , main :: Expr
+  { defs     :: [Definition]
+  , mainExpr :: Expr
   } deriving (Show)
 
 definition :: (Alternative m, Monad m) => Parser String m Definition
@@ -33,9 +33,9 @@ ast = AST <$> some p <*> mainP
       char '\n'
       pure def
     mainP = do
-      def@(name, ex) <- definition
+      (name, ex) <- definition
       guard $ name == "main"
       pure ex
 
 compileAst :: AST -> Either Error String
-compileAst (AST defs main) = betaReduce defs main >>= compile
+compileAst (AST definitions mainEx) = betaReduce definitions mainEx >>= compile

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1,0 +1,41 @@
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+
+module AST where
+
+import Control.Applicative (Alternative, some)
+import Control.Monad (guard)
+
+import Lib (Expr, Identifier, Error, betaReduce, compile)
+import Parser (Parser, char, identifier, expr)
+
+type Definition = (Identifier, Expr)
+
+data AST = AST
+  { defs :: [Definition]
+  , main :: Expr
+  } deriving (Show)
+
+definition :: (Alternative m, Monad m) => Parser String m Definition
+definition = do
+  name <- identifier
+  char ' '
+  char '='
+  char ' '
+  ex <- expr
+  pure (name, ex)
+
+ast :: (Alternative m, Monad m) => Parser String m AST
+ast = AST <$> some p <*> mainP
+  where
+    p = do
+      def@(name, _) <- definition
+      guard $ name /= "main"
+      char '\n'
+      pure def
+    mainP = do
+      def@(name, ex) <- definition
+      guard $ name == "main"
+      pure ex
+
+compileAst :: AST -> Either Error String
+compileAst (AST defs main) = betaReduce defs main >>= compile


### PR DESCRIPTION
Primitive definitions (very rigid syntax)

name = _expr_
main = _top_level_expr_

and a few examples (see .lambda files)

Known issues: this allows symbolic recursion which won't terminate